### PR TITLE
Chore : 카카오 로그인 중복회원 검사 로직 추가

### DIFF
--- a/src/main/java/com/knu/fromnow/api/auth/oauth2/service/Oauth2Service.java
+++ b/src/main/java/com/knu/fromnow/api/auth/oauth2/service/Oauth2Service.java
@@ -54,10 +54,12 @@ public class Oauth2Service {
                     return getMemberByProvider(oauth2Attribute, provider);
                 });
 
-        if (member.getProfileName() == null) {
+        if (member.getRole() == Role.ROLE_NEW_USER) {
             httpStatus = HttpStatus.CREATED;
             message = "새로 회원가입하는 유저입니다!";
         }
+
+        member.setMemberRole(provider);
 
         String accessToken = jwtService.createAccessToken(member.getEmail(), member.getRole().name());
         String refreshToken = jwtService.createRefreshToken();
@@ -67,7 +69,7 @@ public class Oauth2Service {
         ResponseCookie responseCookie = ResponseCookie.from("Authorization-refresh", refreshToken)
                 .httpOnly(true)
                 .sameSite("None")
-                .maxAge(14 * 24 * 60 *60)
+                .maxAge(14 * 24 * 60 * 60)
                 .path("/")
                 .build();
 
@@ -101,9 +103,9 @@ public class Oauth2Service {
         return Oauth2Attribute.of("google", "sub", body);
     }
 
-    private Oauth2Attribute getKakaoData(String idToken){
+    private Oauth2Attribute getKakaoData(String idToken) {
 
-        HashMap<String, Object> attributes= new HashMap<String,Object>();
+        HashMap<String, Object> attributes = new HashMap<String, Object>();
 
         // HTTP Header 생성
         HttpHeaders headers = new HttpHeaders();
@@ -138,23 +140,11 @@ public class Oauth2Service {
     }
 
     private Member getMemberByProvider(Oauth2Attribute oauth2Attribute, String provider) {
-        Member newMember = null;
-
-        if (provider.equals("google")) {
-            newMember = Member.builder()
-                    .role(Role.ROLE_GOOGLE_USER)
-                    .email(oauth2Attribute.getEmail())
-                    .build();
-        }
-
-        if (provider.equals("kakao")) {
-            newMember = Member.builder()
-                    .role(Role.ROLE_KAKAO_USER)
-                    .email(oauth2Attribute.getEmail())
-                    .build();
-        }
+        Member newMember = Member.builder()
+                .role(Role.ROLE_NEW_USER)
+                .email(oauth2Attribute.getEmail())
+                .build();
 
         return newMember;
     }
-
 }

--- a/src/main/java/com/knu/fromnow/api/domain/member/entity/Member.java
+++ b/src/main/java/com/knu/fromnow/api/domain/member/entity/Member.java
@@ -76,4 +76,14 @@ public class Member {
         this.photo = photo;
     }
 
+    public void setMemberRole(String provider){
+       if(provider.equals("google")){
+            this.role = Role.ROLE_GOOGLE_USER;
+       }
+
+       if(provider.equals("kakao")){
+           this.role = Role.ROLE_KAKAO_USER;
+       }
+    }
+
 }

--- a/src/main/java/com/knu/fromnow/api/domain/member/entity/Role.java
+++ b/src/main/java/com/knu/fromnow/api/domain/member/entity/Role.java
@@ -1,5 +1,5 @@
 package com.knu.fromnow.api.domain.member.entity;
 
 public enum Role {
-    ROLE_GOOGLE_USER, ROLE_KAKAO_USER, ROLE_PREMIUM_USER, ROLE_ADMIN
+    ROLE_GOOGLE_USER, ROLE_KAKAO_USER, ROLE_NEW_USER, ROLE_PREMIUM_USER, ROLE_ADMIN
 }


### PR DESCRIPTION
Resolves #11 

## 해결하려는 문제가 무엇인가요?
- 카카오 로그인 시, 기존 회원과 새로운 회원을 구분하지 못하는 걸 수정하고자 합니다.

## 어떻게 해결했나요?
- Member에 Role을 추가하여 새로운 멤버 가입 시 구분할 수 있도록 하였습니다

## 어떤 부분에 집중하여 리뷰해야 할까요?