### PR TITLE
Feat : 프로필 랜덤 이미지 생성 로직 추가

### DIFF
--- a/src/main/java/com/knu/fromnow/api/auth/jwt/controller/JwtController.java
+++ b/src/main/java/com/knu/fromnow/api/auth/jwt/controller/JwtController.java
@@ -3,6 +3,8 @@ package com.knu.fromnow.api.auth.jwt.controller;
 import com.knu.fromnow.api.auth.jwt.service.JwtService;
 import com.knu.fromnow.api.global.spec.ApiBasicResponse;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
@@ -15,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/jwt")
 public class JwtController {
 
+    private static final Logger log = LoggerFactory.getLogger(JwtController.class);
     private final JwtService jwtService;
 
     /**
@@ -24,6 +27,7 @@ public class JwtController {
     public ResponseEntity<ApiBasicResponse> getAccessToken(
             @CookieValue(value = "Authorization-refresh") String refreshToken){
 
+        log.info("token : {}", refreshToken);
         String accessToken = jwtService.getAccessTokenFromRefresh(refreshToken);
 
         return ResponseEntity.ok()

--- a/src/main/java/com/knu/fromnow/api/domain/member/service/MemberService.java
+++ b/src/main/java/com/knu/fromnow/api/domain/member/service/MemberService.java
@@ -68,7 +68,6 @@ public class MemberService {
         Member member = memberRepository.findByEmail(principalDetails.getEmail())
                 .orElseThrow(() -> new MemberException(MemberErrorCode.No_EXIST_EMAIL_MEMBER_EXCEPTION));
 
-
         Photo photo = Photo.builder()
                 .photoUrl(photoUrl)
                 .member(member)

--- a/src/main/java/com/knu/fromnow/api/domain/photo/service/PhotoService.java
+++ b/src/main/java/com/knu/fromnow/api/domain/photo/service/PhotoService.java
@@ -8,6 +8,8 @@ import com.knu.fromnow.api.domain.board.entity.Board;
 import com.knu.fromnow.api.domain.photo.entity.Photo;
 import com.knu.fromnow.api.domain.photo.repository.PhotoRepository;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,6 +17,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Random;
 import java.util.UUID;
 
 @Service
@@ -22,6 +25,7 @@ import java.util.UUID;
 @Transactional
 public class PhotoService {
 
+    private static final Logger log = LoggerFactory.getLogger(PhotoService.class);
     private final PhotoRepository photoRepository;
 
     @Value("${spring.cloud.gcp.storage.bucket}")
@@ -47,6 +51,13 @@ public class PhotoService {
     }
 
     public String uploadImageToGcs(MultipartFile file){
+        if(file.isEmpty()){
+            Random random = new Random();
+            int number = random.nextInt(4) + 1;
+
+            return "https://storage.googleapis.com/fromnow-bucket/basic_image_00" + number + ".png";
+        }
+
         String uniqueFileName = createPhotoName(file);
         BlobId blobId = BlobId.of(bucketName, uniqueFileName);
         BlobInfo blobInfo = BlobInfo.newBuilder(blobId)


### PR DESCRIPTION
Resloves #22 

## 해결하려는 문제가 무엇인가요?
- 사용자가 프로필 사진을 설정하지 않을 시, 랜덤으로 기본 이미지 4개 중 하나를 자동으로 넣어주었습니다 

## 어떻게 해결했나요?
- 사용자가 프로필 사진을 설정하지 않을시, Multipart file이 empty 일 것이고 이를 통해 이미지를 구분하여 넣었습니다.