### PR TITLE
Chore : Photo 엔티티 책임 분리 및 수정

### DIFF
--- a/src/main/java/com/knu/fromnow/api/domain/board/entity/Board.java
+++ b/src/main/java/com/knu/fromnow/api/domain/board/entity/Board.java
@@ -2,7 +2,7 @@ package com.knu.fromnow.api.domain.board.entity;
 
 import com.knu.fromnow.api.domain.diary.entity.Diary;
 import com.knu.fromnow.api.domain.member.entity.Member;
-import com.knu.fromnow.api.domain.photo.entity.Photo;
+import com.knu.fromnow.api.domain.photo.entity.BoardPhoto;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -35,7 +35,7 @@ public class Board {
     private LocalDateTime createdTime;
 
     @OneToMany(mappedBy = "board")
-    private List<Photo> photoList = new ArrayList<>();
+    private List<BoardPhoto> photoList = new ArrayList<>();
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "diary_id")

--- a/src/main/java/com/knu/fromnow/api/domain/board/service/BoardService.java
+++ b/src/main/java/com/knu/fromnow/api/domain/board/service/BoardService.java
@@ -11,17 +11,14 @@ import com.knu.fromnow.api.domain.diary.repository.DiaryRepository;
 import com.knu.fromnow.api.domain.member.entity.Member;
 import com.knu.fromnow.api.domain.member.entity.PrincipalDetails;
 import com.knu.fromnow.api.domain.member.repository.MemberRepository;
-import com.knu.fromnow.api.domain.photo.entity.Photo;
-import com.knu.fromnow.api.domain.photo.service.PhotoService;
+import com.knu.fromnow.api.domain.photo.entity.BoardPhoto;
+import com.knu.fromnow.api.domain.photo.service.BoardPhotoService;
 import com.knu.fromnow.api.global.error.custom.DiaryException;
 import com.knu.fromnow.api.global.error.custom.MemberException;
 import com.knu.fromnow.api.global.error.errorcode.custom.DiaryErrorCode;
 import com.knu.fromnow.api.global.error.errorcode.custom.MemberErrorCode;
 import com.knu.fromnow.api.global.spec.ApiBasicResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -36,7 +33,7 @@ import java.util.List;
 @Transactional
 public class BoardService {
 
-    private final PhotoService photoService;
+    private final BoardPhotoService boardPhotoService;
     private final BoardRepository boardRepository;
     private final MemberRepository memberRepository;
     private final DiaryRepository diaryRepository;
@@ -55,7 +52,7 @@ public class BoardService {
                 .member(member)
                 .build();
 
-        photoService.uploadPhoto(files, board);
+        boardPhotoService.uploadToBoardPhotos(files, board);
 
         member.getBoardList().add(board);
         boardRepository.save(board);
@@ -104,9 +101,9 @@ public class BoardService {
         List<BoardOverViewResponseDto> boardOverViewResponseDtos = new ArrayList<>();
 
         for (Board board : contents) {
-            List<Photo> photoList = board.getPhotoList();
+            List<BoardPhoto> photoList = board.getPhotoList();
             List<String> photoUrls = new ArrayList<>();
-            for (Photo photo : photoList) {
+            for (BoardPhoto photo : photoList) {
                 photoUrls.add(photo.getPhotoUrl());
             }
 
@@ -114,7 +111,7 @@ public class BoardService {
                     BoardOverViewResponseDto.builder()
                             .createdDate(board.getCreatedTime().toString())
                             .profileName(board.getMember().getProfileName())
-                            .profilePhotoUrl(board.getMember().getPhoto().getPhotoUrl())
+                            .profilePhotoUrl(board.getMember().getPhotoUrl())
                             .content(board.getContent())
                             .contentPhotoUrl(photoUrls)
                             .build();

--- a/src/main/java/com/knu/fromnow/api/domain/diary/service/DiaryService.java
+++ b/src/main/java/com/knu/fromnow/api/domain/diary/service/DiaryService.java
@@ -1,11 +1,9 @@
 package com.knu.fromnow.api.domain.diary.service;
 
-import com.knu.fromnow.api.domain.board.entity.Board;
 import com.knu.fromnow.api.domain.board.repository.BoardRepository;
 import com.knu.fromnow.api.domain.diary.dto.request.CreateDiaryDto;
 import com.knu.fromnow.api.domain.diary.dto.request.UpdateDiaryDto;
 import com.knu.fromnow.api.domain.diary.dto.response.ApiDiaryResponse;
-import com.knu.fromnow.api.domain.diary.dto.response.BoardOverViewResponseDto;
 import com.knu.fromnow.api.domain.diary.dto.response.DiaryOverViewResponseDto;
 import com.knu.fromnow.api.domain.diary.entity.Diary;
 import com.knu.fromnow.api.domain.diary.entity.DiaryMember;
@@ -14,16 +12,12 @@ import com.knu.fromnow.api.domain.diary.repository.DiaryRepository;
 import com.knu.fromnow.api.domain.member.entity.Member;
 import com.knu.fromnow.api.domain.member.entity.PrincipalDetails;
 import com.knu.fromnow.api.domain.member.repository.MemberRepository;
-import com.knu.fromnow.api.domain.photo.entity.Photo;
 import com.knu.fromnow.api.global.error.custom.DiaryException;
 import com.knu.fromnow.api.global.error.custom.MemberException;
 import com.knu.fromnow.api.global.error.errorcode.custom.DiaryErrorCode;
 import com.knu.fromnow.api.global.error.errorcode.custom.MemberErrorCode;
 import com.knu.fromnow.api.global.spec.ApiBasicResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/main/java/com/knu/fromnow/api/domain/friend/service/FriendService.java
+++ b/src/main/java/com/knu/fromnow/api/domain/friend/service/FriendService.java
@@ -58,7 +58,7 @@ public class FriendService {
             friendsDtos.add(FriendSearchResponseDto.builder()
                     .memberId(member.getId())
                     .profileName(member.getProfileName())
-                    .profilePhotoUrl(member.getPhoto().getPhotoUrl())
+                    .profilePhotoUrl(member.getPhotoUrl())
                     .isFriend(isFriend)
                     .build());
         }
@@ -84,7 +84,7 @@ public class FriendService {
             friendsDtos.add(FriendBasicResponseDto.builder()
                     .memberId(member.getId())
                     .profileName(member.getProfileName())
-                    .profilePhotoUrl(member.getPhoto().getPhotoUrl())
+                    .profilePhotoUrl(member.getPhotoUrl())
                     .build());
         }
 
@@ -113,7 +113,7 @@ public class FriendService {
                 .fromMemberId(toMember.getId())
                 .toMemberId(fromMember.getId())
                 .areWeFriend(false)
-                .fromMemberProfileUrl(fromMember.getPhoto().getPhotoUrl())
+                .fromMemberProfileUrl(fromMember.getPhotoUrl())
                 .build();
 
         friendRepository.save(sentFriendRequest);
@@ -167,7 +167,7 @@ public class FriendService {
             friendsDtos.add(FriendBasicResponseDto.builder()
                     .memberId(member.getId())
                     .profileName(member.getProfileName())
-                    .profilePhotoUrl(member.getPhoto().getPhotoUrl())
+                    .profilePhotoUrl(member.getPhotoUrl())
                     .build());
         }
 

--- a/src/main/java/com/knu/fromnow/api/domain/member/entity/Member.java
+++ b/src/main/java/com/knu/fromnow/api/domain/member/entity/Member.java
@@ -3,7 +3,6 @@ package com.knu.fromnow.api.domain.member.entity;
 import com.knu.fromnow.api.domain.board.entity.Board;
 import com.knu.fromnow.api.domain.diary.entity.Diary;
 import com.knu.fromnow.api.domain.diary.entity.DiaryMember;
-import com.knu.fromnow.api.domain.photo.entity.Photo;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -12,12 +11,10 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
-import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.checkerframework.checker.units.qual.A;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -35,8 +32,7 @@ public class Member {
     @Enumerated(EnumType.STRING)
     private Role role;
 
-    @OneToOne(mappedBy = "member")
-    private Photo photo;
+    private String photoUrl;
 
     private String email;
 
@@ -72,8 +68,8 @@ public class Member {
         this.profileName = profileName;
     }
 
-    public void setMemberPhoto(Photo photo){
-        this.photo = photo;
+    public void setMemberPhoto(String photoUrl){
+        this.photoUrl = photoUrl;
     }
 
     public void setMemberRole(String provider){

--- a/src/main/java/com/knu/fromnow/api/domain/member/service/MemberService.java
+++ b/src/main/java/com/knu/fromnow/api/domain/member/service/MemberService.java
@@ -5,9 +5,8 @@ import com.knu.fromnow.api.domain.member.dto.request.CreateMemberDto;
 import com.knu.fromnow.api.domain.member.entity.Member;
 import com.knu.fromnow.api.domain.member.entity.PrincipalDetails;
 import com.knu.fromnow.api.domain.member.repository.MemberRepository;
-import com.knu.fromnow.api.domain.photo.entity.Photo;
-import com.knu.fromnow.api.domain.photo.repository.PhotoRepository;
-import com.knu.fromnow.api.domain.photo.service.PhotoService;
+import com.knu.fromnow.api.domain.photo.repository.BoardPhotoRepository;
+import com.knu.fromnow.api.domain.photo.service.BoardPhotoService;
 import com.knu.fromnow.api.global.error.custom.MemberException;
 import com.knu.fromnow.api.global.error.errorcode.custom.MemberErrorCode;
 import com.knu.fromnow.api.global.spec.ApiBasicResponse;
@@ -22,9 +21,9 @@ import org.springframework.web.multipart.MultipartFile;
 public class MemberService {
 
     private final MemberRepository memberRepository;
-    private final PhotoService photoService;
+    private final BoardPhotoService boardPhotoService;
     private final JwtService jwtService;
-    private final PhotoRepository photoRepository;
+    private final BoardPhotoRepository boardPhotoRepository;
 
     /**
      * ProfileName 중복 체크 로직
@@ -63,16 +62,11 @@ public class MemberService {
     }
 
     public ApiBasicResponse setMemberPhoto(MultipartFile file, PrincipalDetails principalDetails){
-        String photoUrl = photoService.uploadImageToGcs(file);
-
         Member member = memberRepository.findByEmail(principalDetails.getEmail())
                 .orElseThrow(() -> new MemberException(MemberErrorCode.No_EXIST_EMAIL_MEMBER_EXCEPTION));
 
-        Photo photo = Photo.builder()
-                .photoUrl(photoUrl)
-                .member(member)
-                .build();
-        photoRepository.save(photo);
+        String photoUrl = boardPhotoService.uploadImageToGcs(file);
+        member.setMemberPhoto(photoUrl);
 
         return ApiBasicResponse.builder()
                 .status(true)

--- a/src/main/java/com/knu/fromnow/api/domain/photo/entity/BoardPhoto.java
+++ b/src/main/java/com/knu/fromnow/api/domain/photo/entity/BoardPhoto.java
@@ -1,7 +1,6 @@
 package com.knu.fromnow.api.domain.photo.entity;
 
 import com.knu.fromnow.api.domain.board.entity.Board;
-import com.knu.fromnow.api.domain.member.entity.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -10,28 +9,20 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
-
-@Entity(name = "photos")
+@Entity(name = "board_photos")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class Photo {
+public class BoardPhoto {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "photo_id")
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "board_photo_id")
     private Long id;
-
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
-    private Member member;
-
-    private LocalDateTime createdTime;
 
     private String photoUrl;
 
@@ -40,9 +31,7 @@ public class Photo {
     private Board board;
 
     @Builder
-    public Photo(Member member, LocalDateTime createdTime, String photoUrl, Board board) {
-        this.member = member;
-        this.createdTime = LocalDateTime.now();
+    public BoardPhoto(String photoUrl, Board board) {
         this.photoUrl = photoUrl;
         this.board = board;
     }

--- a/src/main/java/com/knu/fromnow/api/domain/photo/repository/BoardPhotoRepository.java
+++ b/src/main/java/com/knu/fromnow/api/domain/photo/repository/BoardPhotoRepository.java
@@ -1,0 +1,7 @@
+package com.knu.fromnow.api.domain.photo.repository;
+
+import com.knu.fromnow.api.domain.photo.entity.BoardPhoto;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BoardPhotoRepository extends JpaRepository<BoardPhoto, Long> {
+}

--- a/src/main/java/com/knu/fromnow/api/domain/photo/repository/PhotoRepository.java
+++ b/src/main/java/com/knu/fromnow/api/domain/photo/repository/PhotoRepository.java
@@ -1,7 +1,0 @@
-package com.knu.fromnow.api.domain.photo.repository;
-
-import com.knu.fromnow.api.domain.photo.entity.Photo;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface PhotoRepository extends JpaRepository<Photo, Long> {
-}

--- a/src/main/java/com/knu/fromnow/api/domain/photo/service/BoardPhotoService.java
+++ b/src/main/java/com/knu/fromnow/api/domain/photo/service/BoardPhotoService.java
@@ -5,8 +5,8 @@ import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
 import com.knu.fromnow.api.domain.board.entity.Board;
-import com.knu.fromnow.api.domain.photo.entity.Photo;
-import com.knu.fromnow.api.domain.photo.repository.PhotoRepository;
+import com.knu.fromnow.api.domain.photo.entity.BoardPhoto;
+import com.knu.fromnow.api.domain.photo.repository.BoardPhotoRepository;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,10 +23,9 @@ import java.util.UUID;
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class PhotoService {
+public class BoardPhotoService {
 
-    private static final Logger log = LoggerFactory.getLogger(PhotoService.class);
-    private final PhotoRepository photoRepository;
+    private final BoardPhotoRepository boardPhotoRepository;
 
     @Value("${spring.cloud.gcp.storage.bucket}")
     private String bucketName;
@@ -36,17 +35,16 @@ public class PhotoService {
 
     private final Storage storage;
 
-
-    public void uploadPhoto(MultipartFile[] files, Board board){
+    public void uploadToBoardPhotos(MultipartFile[] files, Board board){
         for (MultipartFile file : files) {
             String photoUrl = uploadImageToGcs(file);
-            Photo photo = Photo.builder()
+            BoardPhoto photo = BoardPhoto.builder()
                     .board(board)
                     .photoUrl(photoUrl)
                     .build();
 
             board.getPhotoList().add(photo);
-            photoRepository.save(photo);
+            boardPhotoRepository.save(photo);
         }
     }
 


### PR DESCRIPTION
Resovles #27 

## 해결하려는 문제가 무엇인가요?
- Photo가 현재 member의 프로필 사진을 설정하는데 사용되고, Board의 여러 사진을 업로드 하는데도 사용된다
즉 단일 책임 원칙을 위반하며, 데이터의 관점에서 무결성 문제가 있다

## 어떻게 해결했나요?
- Member의 프로필 사진은 Member 엔티티내에 추가하였고, 게시글에 여러 사진은 BoardPhoto로 엔티티를 분리하여 관리하였다