### PR TITLE
FEAT : 모임 초대 및 수락, 마이페이지 조회 기능 구현

### DIFF
--- a/src/main/java/com/knu/fromnow/api/auth/jwt/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/knu/fromnow/api/auth/jwt/filter/JwtAuthorizationFilter.java
@@ -34,7 +34,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
         // filter를 거치고 싶지 않은 path를 여기서 관리함
-        String[] excludePathLists = {"/favicon.ico", "/swagger-ui/index.html", "/api/jwt/reissue"};
+        String[] excludePathLists = {"/favicon.ico", "/swagger-ui/index.html", "/api/jwt/access-token"};
         String[] excludePathStartsWithLists = {"/login", "/oauth2", "/api/member/check", "/v3", "/swagger-ui", "/ws", "/api/oauth2"};
 
         String path = request.getRequestURI();

--- a/src/main/java/com/knu/fromnow/api/domain/diary/controller/ApiDiaryController.java
+++ b/src/main/java/com/knu/fromnow/api/domain/diary/controller/ApiDiaryController.java
@@ -1,10 +1,11 @@
 package com.knu.fromnow.api.domain.diary.controller;
 
 
+import com.knu.fromnow.api.domain.diary.dto.request.AcceptDiaryDto;
 import com.knu.fromnow.api.domain.diary.dto.request.CreateDiaryDto;
+import com.knu.fromnow.api.domain.diary.dto.request.InviteToDiaryDto;
 import com.knu.fromnow.api.domain.diary.dto.request.UpdateDiaryDto;
 import com.knu.fromnow.api.domain.diary.dto.response.ApiDiaryResponse;
-import com.knu.fromnow.api.domain.diary.dto.response.BoardOverViewResponseDto;
 import com.knu.fromnow.api.domain.diary.dto.response.DiaryOverViewResponseDto;
 import com.knu.fromnow.api.domain.diary.service.DiaryService;
 import com.knu.fromnow.api.domain.member.entity.PrincipalDetails;
@@ -20,7 +21,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -28,7 +28,7 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/diary")
-public class ApiDiaryController implements SwaggerDiaryApi{
+public class ApiDiaryController implements SwaggerDiaryApi {
 
     private final DiaryService diaryService;
 
@@ -36,7 +36,7 @@ public class ApiDiaryController implements SwaggerDiaryApi{
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ApiBasicResponse> createDiary(
             @RequestBody CreateDiaryDto createDiaryDto,
-            @AuthenticationPrincipal PrincipalDetails principalDetails){
+            @AuthenticationPrincipal PrincipalDetails principalDetails) {
 
         ApiBasicResponse apiBasicResponse = diaryService.createDiary(createDiaryDto, principalDetails);
 
@@ -47,10 +47,32 @@ public class ApiDiaryController implements SwaggerDiaryApi{
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ApiDiaryResponse<List<DiaryOverViewResponseDto>>> getDiaryOverView(
             @AuthenticationPrincipal PrincipalDetails principalDetails
-    ){
+    ) {
         ApiDiaryResponse<List<DiaryOverViewResponseDto>> diaryOverView = diaryService.getDiaryOverView(principalDetails);
 
         return ResponseEntity.status(diaryOverView.getCode()).body(diaryOverView);
+    }
+
+    @PostMapping("/invite")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiBasicResponse> inviteToDiary(
+            @RequestBody InviteToDiaryDto inviteToDiaryDto,
+            @AuthenticationPrincipal PrincipalDetails principalDetails
+    ) {
+        ApiBasicResponse response = diaryService.inviteToDiary(inviteToDiaryDto, principalDetails);
+
+        return ResponseEntity.status(response.getCode()).body(response);
+    }
+
+    @PostMapping("/accept")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiBasicResponse> acceptedInvite(
+            @RequestBody AcceptDiaryDto acceptDiaryDto,
+            @AuthenticationPrincipal PrincipalDetails principalDetails
+    ) {
+        ApiBasicResponse response = diaryService.acceptInvite(acceptDiaryDto, principalDetails);
+
+        return ResponseEntity.status(response.getCode()).body(response);
     }
 
 
@@ -60,7 +82,7 @@ public class ApiDiaryController implements SwaggerDiaryApi{
             @PathVariable("diaryId") Long diaryId,
             @RequestBody UpdateDiaryDto updateDiarydto,
             @AuthenticationPrincipal PrincipalDetails principalDetails
-    ){
+    ) {
         ApiBasicResponse response = diaryService.updateDiaryTitle(updateDiarydto, principalDetails, diaryId);
 
         return ResponseEntity.status(response.getCode()).body(response);
@@ -71,7 +93,7 @@ public class ApiDiaryController implements SwaggerDiaryApi{
     public ResponseEntity<ApiBasicResponse> deleteDiary(
             @PathVariable("diaryId") Long diaryId,
             @AuthenticationPrincipal PrincipalDetails principalDetails
-    ){
+    ) {
         ApiBasicResponse response = diaryService.deleteDiary(principalDetails, diaryId);
 
         return ResponseEntity.status(response.getCode()).body(response);

--- a/src/main/java/com/knu/fromnow/api/domain/diary/dto/request/AcceptDiaryDto.java
+++ b/src/main/java/com/knu/fromnow/api/domain/diary/dto/request/AcceptDiaryDto.java
@@ -1,0 +1,8 @@
+package com.knu.fromnow.api.domain.diary.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class AcceptDiaryDto {
+    private Long diaryId;
+}

--- a/src/main/java/com/knu/fromnow/api/domain/diary/dto/request/InviteToDiaryDto.java
+++ b/src/main/java/com/knu/fromnow/api/domain/diary/dto/request/InviteToDiaryDto.java
@@ -1,0 +1,9 @@
+package com.knu.fromnow.api.domain.diary.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class InviteToDiaryDto {
+    private Long diaryId;
+    private String profileName;
+}

--- a/src/main/java/com/knu/fromnow/api/domain/diary/dto/response/DiaryRequestsReceivedDto.java
+++ b/src/main/java/com/knu/fromnow/api/domain/diary/dto/response/DiaryRequestsReceivedDto.java
@@ -1,0 +1,18 @@
+package com.knu.fromnow.api.domain.diary.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class DiaryRequestsReceivedDto {
+    private String diaryTitle;
+    private Long diaryId;
+
+    @Builder
+    public DiaryRequestsReceivedDto(String diaryTitle, Long diaryId) {
+        this.diaryTitle = diaryTitle;
+        this.diaryId = diaryId;
+    }
+}

--- a/src/main/java/com/knu/fromnow/api/domain/diary/entity/DiaryMember.java
+++ b/src/main/java/com/knu/fromnow/api/domain/diary/entity/DiaryMember.java
@@ -1,6 +1,7 @@
 package com.knu.fromnow.api.domain.diary.entity;
 
 import com.knu.fromnow.api.domain.member.entity.Member;
+import com.knu.fromnow.api.global.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -19,7 +20,7 @@ import lombok.NoArgsConstructor;
 @Entity(name = "Diary_Member")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class DiaryMember {
+public class DiaryMember extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "diary_member_id")
@@ -33,9 +34,16 @@ public class DiaryMember {
     @JoinColumn(name = "member_id")
     private Member member;
 
+    private boolean acceptedInvite;
+
     @Builder
-    public DiaryMember(Diary diary, Member member) {
+    public DiaryMember(Diary diary, Member member, boolean acceptedInvite) {
         this.diary = diary;
         this.member = member;
+        this.acceptedInvite = acceptedInvite;
+    }
+
+    public void acceptInvitation(){
+        this.acceptedInvite = true;
     }
 }

--- a/src/main/java/com/knu/fromnow/api/domain/diary/repository/DiaryMemberCustomRepository.java
+++ b/src/main/java/com/knu/fromnow/api/domain/diary/repository/DiaryMemberCustomRepository.java
@@ -1,0 +1,11 @@
+package com.knu.fromnow.api.domain.diary.repository;
+
+import com.knu.fromnow.api.domain.member.entity.Member;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+public interface DiaryMemberCustomRepository {
+    List<Long> getUnacceptedDiaryIdsByMember(Member member);
+}

--- a/src/main/java/com/knu/fromnow/api/domain/diary/repository/DiaryMemberCustomRepositoryImpl.java
+++ b/src/main/java/com/knu/fromnow/api/domain/diary/repository/DiaryMemberCustomRepositoryImpl.java
@@ -1,0 +1,29 @@
+package com.knu.fromnow.api.domain.diary.repository;
+
+import com.knu.fromnow.api.domain.diary.entity.QDiaryMember;
+import com.knu.fromnow.api.domain.member.entity.Member;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class DiaryMemberCustomRepositoryImpl implements DiaryMemberCustomRepository{
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<Long> getUnacceptedDiaryIdsByMember(Member member) {
+
+        QDiaryMember diaryMember = QDiaryMember.diaryMember;
+
+        return jpaQueryFactory.select(diaryMember.diary.id)
+                .from(diaryMember)
+                .where(diaryMember.member.eq(member),
+                        diaryMember.acceptedInvite.isFalse())
+                .fetch();
+    }
+}

--- a/src/main/java/com/knu/fromnow/api/domain/diary/repository/DiaryMemberRepository.java
+++ b/src/main/java/com/knu/fromnow/api/domain/diary/repository/DiaryMemberRepository.java
@@ -1,13 +1,18 @@
 package com.knu.fromnow.api.domain.diary.repository;
 
+import com.knu.fromnow.api.domain.diary.entity.Diary;
 import com.knu.fromnow.api.domain.diary.entity.DiaryMember;
+import com.knu.fromnow.api.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface DiaryMemberRepository extends JpaRepository<DiaryMember, Long> {
     @Query("SELECT dm.diary.id FROM Diary_Member dm WHERE dm.member.id = :memberId")
     List<Long> findDiaryIdsByMemberId(@Param("memberId") Long memberId);
+
+    Optional<DiaryMember> findByDiaryAndMember(Diary diary, Member member);
 }

--- a/src/main/java/com/knu/fromnow/api/domain/diary/service/DiaryMemberService.java
+++ b/src/main/java/com/knu/fromnow/api/domain/diary/service/DiaryMemberService.java
@@ -1,13 +1,72 @@
 package com.knu.fromnow.api.domain.diary.service;
 
+import com.knu.fromnow.api.domain.diary.dto.response.DiaryRequestsReceivedDto;
+import com.knu.fromnow.api.domain.diary.entity.Diary;
+import com.knu.fromnow.api.domain.diary.entity.DiaryMember;
+import com.knu.fromnow.api.domain.diary.repository.DiaryMemberCustomRepository;
 import com.knu.fromnow.api.domain.diary.repository.DiaryMemberRepository;
+import com.knu.fromnow.api.domain.diary.repository.DiaryRepository;
+import com.knu.fromnow.api.domain.member.entity.Member;
+import com.knu.fromnow.api.domain.member.entity.PrincipalDetails;
+import com.knu.fromnow.api.domain.member.repository.MemberRepository;
+import com.knu.fromnow.api.global.error.custom.MemberException;
+import com.knu.fromnow.api.global.error.errorcode.custom.MemberErrorCode;
+import com.knu.fromnow.api.global.spec.ApiDataResponse;
 import lombok.RequiredArgsConstructor;
+import org.checkerframework.checker.units.qual.A;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class DiaryMemberService {
+    private final MemberRepository memberRepository;
     private final DiaryMemberRepository diaryMemberRepository;
+    private final DiaryMemberCustomRepository diaryMemberCustomRepository;
+    private final DiaryRepository diaryRepository;
+
+    public void inviteMemberToDiary(Diary diary, Member member){
+        DiaryMember diaryMember = DiaryMember.builder()
+                .diary(diary)
+                .member(member)
+                .acceptedInvite(false)
+                .build();
+
+        diaryMemberRepository.save(diaryMember);
+    }
+
+    public ApiDataResponse<List<DiaryRequestsReceivedDto>> getDiaryRequestsReceived(PrincipalDetails principalDetails) {
+        Member member = memberRepository.findByEmail(principalDetails.getEmail())
+                .orElseThrow(() -> new MemberException(MemberErrorCode.No_EXIST_EMAIL_MEMBER_EXCEPTION));
+
+        List<Long> diaryIds = diaryMemberCustomRepository.getUnacceptedDiaryIdsByMember(member);
+        List<Diary> diaryList = diaryRepository.findByIdIn(diaryIds);
+
+        List<DiaryRequestsReceivedDto> diaryRequestsReceivedDtos = getDiaryRequestsReceivedDtos(diaryList);
+
+        return ApiDataResponse.<List<DiaryRequestsReceivedDto>>builder()
+                .status(true)
+                .code(200)
+                .message("내가 받은 모임 요청 리스트 반환 성공!")
+                .data(diaryRequestsReceivedDtos)
+                .build();
+    }
+
+
+
+    private static List<DiaryRequestsReceivedDto> getDiaryRequestsReceivedDtos(List<Diary> diaryList) {
+        List<DiaryRequestsReceivedDto> diaryRequestsReceivedDtos = new ArrayList<>();
+        for (Diary diary : diaryList) {
+            DiaryRequestsReceivedDto diaryRequestsReceivedDto = DiaryRequestsReceivedDto.builder()
+                    .diaryId(diary.getId())
+                    .diaryTitle(diary.getTitle())
+                    .build();
+            diaryRequestsReceivedDtos.add(diaryRequestsReceivedDto);
+        }
+        return diaryRequestsReceivedDtos;
+    }
 }

--- a/src/main/java/com/knu/fromnow/api/domain/friend/service/FriendService.java
+++ b/src/main/java/com/knu/fromnow/api/domain/friend/service/FriendService.java
@@ -153,7 +153,7 @@ public class FriendService {
                 .build();
     }
 
-    public ApiDataResponse<List<FriendBasicResponseDto>> getRequestsReceived(PrincipalDetails principalDetails) {
+    public ApiDataResponse<List<FriendBasicResponseDto>> getFriendRequestsReceived(PrincipalDetails principalDetails) {
         // from이 나인데, are we가 false인 모든 to들을 가져오기
         Member fromMember = memberRepository.findByEmail(principalDetails.getEmail())
                 .orElseThrow(() -> new MemberException(MemberErrorCode.No_EXIST_EMAIL_MEMBER_EXCEPTION));

--- a/src/main/java/com/knu/fromnow/api/domain/mypage/controller/ApiMyController.java
+++ b/src/main/java/com/knu/fromnow/api/domain/mypage/controller/ApiMyController.java
@@ -1,6 +1,9 @@
 package com.knu.fromnow.api.domain.mypage.controller;
 
 import com.knu.fromnow.api.domain.diary.dto.response.BoardOverViewResponseDto;
+import com.knu.fromnow.api.domain.diary.dto.response.DiaryRequestsReceivedDto;
+import com.knu.fromnow.api.domain.diary.service.DiaryMemberService;
+import com.knu.fromnow.api.domain.diary.service.DiaryService;
 import com.knu.fromnow.api.domain.friend.dto.response.FriendBasicResponseDto;
 import com.knu.fromnow.api.domain.friend.service.FriendService;
 import com.knu.fromnow.api.domain.like.service.LikeService;
@@ -23,6 +26,8 @@ public class ApiMyController implements SwaggerMyApi{
 
     private final LikeService likeService;
     private final FriendService friendService;
+    private final DiaryService diaryService;
+    private final DiaryMemberService diaryMemberService;
 
     @GetMapping("/likes")
     @PreAuthorize("isAuthenticated()")
@@ -46,10 +51,20 @@ public class ApiMyController implements SwaggerMyApi{
 
     @GetMapping("/friend/requests/received")
     @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<ApiDataResponse<List<FriendBasicResponseDto>>> getRequestsReceived(
+    public ResponseEntity<ApiDataResponse<List<FriendBasicResponseDto>>> getFriendRequestsReceived(
             @AuthenticationPrincipal PrincipalDetails principalDetails
     ){
-        ApiDataResponse<List<FriendBasicResponseDto>> response = friendService.getRequestsReceived(principalDetails);
+        ApiDataResponse<List<FriendBasicResponseDto>> response = friendService.getFriendRequestsReceived(principalDetails);
+
+        return ResponseEntity.status(response.getCode()).body(response);
+    }
+
+    @GetMapping("/diary/requests/received")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiDataResponse<List<DiaryRequestsReceivedDto>>> getDiaryRequestsReceived(
+            @AuthenticationPrincipal PrincipalDetails principalDetails
+    ){
+        ApiDataResponse<List<DiaryRequestsReceivedDto>> response = diaryMemberService.getDiaryRequestsReceived(principalDetails);
 
         return ResponseEntity.status(response.getCode()).body(response);
     }

--- a/src/main/java/com/knu/fromnow/api/domain/mypage/controller/SwaggerMyApi.java
+++ b/src/main/java/com/knu/fromnow/api/domain/mypage/controller/SwaggerMyApi.java
@@ -41,6 +41,6 @@ public interface SwaggerMyApi {
             }
     )
     @Operation(summary = "받은 친구 요청 조회", description = "받은 친구 요청 조회")
-    ResponseEntity<ApiDataResponse<List<FriendBasicResponseDto>>> getRequestsReceived(
+    ResponseEntity<ApiDataResponse<List<FriendBasicResponseDto>>> getFriendRequestsReceived(
             @Parameter PrincipalDetails principalDetails);
 }

--- a/src/main/java/com/knu/fromnow/api/global/error/ExControllerAdvice.java
+++ b/src/main/java/com/knu/fromnow/api/global/error/ExControllerAdvice.java
@@ -1,5 +1,6 @@
 package com.knu.fromnow.api.global.error;
 
+import com.knu.fromnow.api.global.error.custom.DiaryMemberException;
 import com.knu.fromnow.api.global.error.custom.FriendException;
 import com.knu.fromnow.api.global.error.custom.MemberException;
 import com.knu.fromnow.api.global.error.custom.JwtTokenException;
@@ -66,6 +67,13 @@ public class ExControllerAdvice {
     @ExceptionHandler(JwtTokenException.class)
     public ResponseEntity<ApiErrorResponse> handleNotValidTokenException(JwtTokenException e){
         ApiErrorResponse apiErrorResponse = buildErrorResponseWithCustomException(e.getJwtTokenErrorCode());
+        return buildResponseEntity(apiErrorResponse);
+    }
+
+    // DiaryMemberException 처리
+    @ExceptionHandler(DiaryMemberException.class)
+    public ResponseEntity<ApiErrorResponse> handleDiaryMemberException(DiaryMemberException e){
+        ApiErrorResponse apiErrorResponse = buildErrorResponseWithCustomException(e.getDiaryMemberErrorCode());
         return buildResponseEntity(apiErrorResponse);
     }
 

--- a/src/main/java/com/knu/fromnow/api/global/error/custom/DiaryMemberException.java
+++ b/src/main/java/com/knu/fromnow/api/global/error/custom/DiaryMemberException.java
@@ -1,0 +1,14 @@
+package com.knu.fromnow.api.global.error.custom;
+
+import com.knu.fromnow.api.global.error.errorcode.custom.DiaryMemberErrorCode;
+import lombok.Getter;
+
+@Getter
+public class DiaryMemberException extends RuntimeException{
+
+    private DiaryMemberErrorCode diaryMemberErrorCode;
+
+    public DiaryMemberException(DiaryMemberErrorCode diaryMemberErrorCode) {
+        this.diaryMemberErrorCode = diaryMemberErrorCode;
+    }
+}

--- a/src/main/java/com/knu/fromnow/api/global/error/errorcode/custom/DiaryMemberErrorCode.java
+++ b/src/main/java/com/knu/fromnow/api/global/error/errorcode/custom/DiaryMemberErrorCode.java
@@ -1,0 +1,22 @@
+package com.knu.fromnow.api.global.error.errorcode.custom;
+
+import com.knu.fromnow.api.global.error.errorcode.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum DiaryMemberErrorCode implements ErrorCode {
+
+    NO_EXIST_DIARY_MEMBER_EXCEPTION(HttpStatus.BAD_REQUEST, "해당 멤버와 다이어리에 해당하는 엔티티가 없습니다"),
+    ALREADY_ACCEPTED_INVITATION_EXCEPTION(HttpStatus.BAD_REQUEST, "이미 초대를 수락한 유저입니다");
+
+   DiaryMemberErrorCode(HttpStatus httpStatus, String message) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+
+    private HttpStatus httpStatus;
+    private String message;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,7 @@
 spring:
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         show_sql: true


### PR DESCRIPTION
Resovles #20 #33

## 해결하려는 문제가 무엇인가요?
- 모임(diary) 초대 및 수락, 마이페이지에서 내가 초대받은 모임 조회하기 기능 구현

## 어떻게 해결했나요?
- DiaryMember 엔티티에 메타정보를 추가하였고, 서비스 로직을 작성했습니다
